### PR TITLE
logobj and log formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ access git revision state in node
 # Example
 
 ``` js
-var git = require('git-rev')
-
 git.short(function (str) {
   console.log('short', str)
   // => aefdd94
@@ -27,6 +25,69 @@ git.tag(function (str) {
   // => 0.1.0
 })
 
+git.log(function (array) {
+  console.log('log', inspect(array, { colors: true }));
+  // [ [ '8ff80cfe54ca7fe4cb1fa780d146266c4145544d',
+  //     'xoorath',
+  //     '16 hours ago',
+  //     'in progress: building command string :cactus:' ],
+  //   [ 'cfb8a8fb9bd311698a1ca4b451656c79a28272fc',
+  //     'xoorath',
+  //     '16 hours ago',
+  //     'in progress: working on property info and logobj' ],
+  //   [ '7f0439b4f66c0cf2fd899ece0a036e63211c811f',
+  //     'Roman Jurkov',
+  //     '26 hours ago',
+  //     'incorporated changes by @xoorath' ] ]
+}, 3)
+
+git.log(function (array) {
+  console.log('log', inspect(array, { colors: true }));
+  // [ [ '8ff80cf', '8ff80cfe54ca7fe4cb1fa780d146266c4145544d' ],
+  //   [ 'cfb8a8f', 'cfb8a8fb9bd311698a1ca4b451656c79a28272fc' ],
+  //   [ '7f0439b', '7f0439b4f66c0cf2fd899ece0a036e63211c811f' ] ]
+}, 3, ['%h', '%H'])
+
+git.logobj(function(array) {
+  console.log('logobj', inspect(array, { depth: 4, colors: true }));
+  // [ { commit: 
+  //      { long_hash: '8ff80cfe54ca7fe4cb1fa780d146266c4145544d',
+  //        short_hash: '8ff80cf' },
+  //     tree: 
+  //      { long_hash: '342c2b67449641ea2dd81e9f94851ab2decffaff',
+  //        short_hash: '342c2b6' },
+  //     author: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     committer: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     message: 
+  //      { encoding: '',
+  //        subject: 'in progress: building command string :cactus:',
+  //        body: '',
+  //        signature: { good: 'N', signer: '', key: '' } } } ]
+
+    for(var  i = 0; i < array.length; ++i) {
+      console.log('log.commit.short_hash', array[i].commit.short_hash);
+      console.log('log.author.name', array[i].author.name);
+      console.log('log.message.subject', array[i].message.subject);
+      // => log.commit.short_hash 8ff80cf
+      // => log.author.name xoorath
+      // => log.message.subject in progress: building command string :cactus:
+    }
+}, 1)
+
 ```
 
 # Methods
@@ -35,9 +96,20 @@ git.tag(function (str) {
 var git = require('git-rev')
 ```
 
-## .log(function (array) { ... })
-return the git log of `process.cwd()` as an array
+## .log(function (array) { ... }, limit, format)
+return the git log of `process.cwd()` as an array.
 
+#### param: limit
+> default: `limit = undefined`
+
+limits the number of logs to fetch. Default is no limit (limit === undefined).
+
+#### param: format
+> default: `format = ['%H', '%an', '%cr', '%s']`
+ 
+An array of format strings (see: http://git-scm.com/docs/pretty-formats) for details.
+
+#### log example
 ``` js
 git.log(function (array) {
   console.log('log', array)
@@ -53,7 +125,79 @@ git.log(function (array) {
   //     'first commit',
   //     '2 days ago',
   //     'Thomas Blobaum' ] ]
-})
+}, 3)
+```
+
+## .logobj(function (array) { ... }, limit)
+return the git log of `process.cwd()` as an array of objects.
+
+The object returned has the following format
+``` js
+array[0].commit.long_hash; // '8ff80cfe54ca7fe4cb1fa780d146266c4145544d'
+array[0].commit.short_hash; // '8ff80cf'
+
+array[0].tree.long_hash; // '342c2b67449641ea2dd81e9f94851ab2decffaff'
+array[0].tree.short_hash; // '342c2b6'
+
+array[0].author.name; // 'xoorath'
+array[0].author.email; // 'jared@xoorath.com'
+array[0].author.date.unix; // '1449358043'
+array[0].author.date.relative; // '16 hours ago'
+array[0].author.date.ISO; // '2015-12-05 18:27:23 -0500'
+array[0].author.date.date_obj; // new Date();
+
+array[0].committer.name; // 'xoorath'
+array[0].committer.email; // 'jared@xoorath.com'
+array[0].committer.date.unix; // '1449358043'
+array[0].committer.date.relative; // '16 hours ago'
+array[0].committer.date.ISO; // '2015-12-05 18:27:23 -0500'
+array[0].committer.date.date_obj; // new Date();
+
+array[0].message.encoding; // ''
+array[0].message.subject; // 'in progress: building command string :cactus:'
+array[0].message.body; // ''
+array[0].message.signature.good; // 'N';
+array[0].message.signature.signer; // '';
+array[0].message.signature.key; // '';
+```
+
+#### param: limit
+> default: `limit = undefined`
+
+limits the number of logs to fetch. Default is no limit (limit === undefined).
+
+#### logobj example
+``` js
+git.logobj(function(array) {
+  console.log('logobj', inspect(array, { depth: 4, colors: true }));
+  // [ { commit: 
+  //      { long_hash: '8ff80cfe54ca7fe4cb1fa780d146266c4145544d',
+  //        short_hash: '8ff80cf' },
+  //     tree: 
+  //      { long_hash: '342c2b67449641ea2dd81e9f94851ab2decffaff',
+  //        short_hash: '342c2b6' },
+  //     author: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     committer: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     message: 
+  //      { encoding: '',
+  //        subject: 'in progress: building command string :cactus:',
+  //        body: '',
+  //        signature: { good: 'N', signer: '', key: '' } } } ]
+}, 1)
 ```
 
 ## .short(function (commit) { ... })

--- a/example/simple.js
+++ b/example/simple.js
@@ -1,4 +1,5 @@
 var git = require('../')
+var inspect = require('util').inspect;
 
 git.short(function (str) {
   console.log('short', str)
@@ -21,21 +22,64 @@ git.tag(function (str) {
 })
 
 git.log(function (array) {
-  console.log('log', array)
-  // [ [ 'aefdd946ea65c88f8aa003e46474d57ed5b291d1',
-  //     'add description',
-  //     '7 hours ago',
-  //     'Thomas Blobaum' ],
-  //   [ '1eb9a6c8633a5a47a47487f17b17ae545d0e26a8',
-  //     'first',
-  //     '7 hours ago',
-  //     'Thomas Blobaum' ],
-  //   [ '7f85b750b908d28bfeb13ad6dba47d9d604508f9',
-  //     'first commit',
-  //     '2 days ago',
-  //     'Thomas Blobaum' ] ]
-}, 5)
+  console.log('log', inspect(array, { colors: true }));
+  // => [ [ '8ff80cfe54ca7fe4cb1fa780d146266c4145544d',
+  //     'xoorath',
+  //     '16 hours ago',
+  //     'in progress: building command string :cactus:' ],
+  //   [ 'cfb8a8fb9bd311698a1ca4b451656c79a28272fc',
+  //     'xoorath',
+  //     '16 hours ago',
+  //     'in progress: working on property info and logobj' ],
+  //   [ '7f0439b4f66c0cf2fd899ece0a036e63211c811f',
+  //     'Roman Jurkov',
+  //     '26 hours ago',
+  //     'incorporated changes by @xoorath' ] ]
+}, 3)
+
+git.log(function (array) {
+  console.log('log', inspect(array, { colors: true }));
+  // => [ [ '8ff80cf', '8ff80cfe54ca7fe4cb1fa780d146266c4145544d' ],
+  //   [ 'cfb8a8f', 'cfb8a8fb9bd311698a1ca4b451656c79a28272fc' ],
+  //   [ '7f0439b', '7f0439b4f66c0cf2fd899ece0a036e63211c811f' ] ]
+}, 3, ['%h', '%H'])
 
 git.logobj(function(array) {
-  console.log('logobj', array);
-}, 5)
+  console.log('logobj', inspect(array, { depth: 4, colors: true }));
+  // => [ { commit: 
+  //      { long_hash: '8ff80cfe54ca7fe4cb1fa780d146266c4145544d',
+  //        short_hash: '8ff80cf' },
+  //     tree: 
+  //      { long_hash: '342c2b67449641ea2dd81e9f94851ab2decffaff',
+  //        short_hash: '342c2b6' },
+  //     author: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     committer: 
+  //      { name: 'xoorath',
+  //        email: 'jared@xoorath.com',
+  //        date: 
+  //         { unix: '1449358043',
+  //           relative: '16 hours ago',
+  //           ISO: '2015-12-05 18:27:23 -0500',
+  //           date_obj: Sun Dec 06 2015 10:28:57 GMT-0500 (EST) } },
+  //     message: 
+  //      { encoding: '',
+  //        subject: 'in progress: building command string :cactus:',
+  //        body: '',
+  //        signature: { good: 'N', signer: '', key: '' } } } ]
+
+    for(var  i = 0; i < array.length; ++i) {
+      console.log('log.commit.short_hash', array[i].commit.short_hash);
+      console.log('log.author.name', array[i].author.name);
+      console.log('log.message.subject', array[i].message.subject);
+      // => log.commit.short_hash 8ff80cf
+      // => log.author.name xoorath
+      // => log.message.subject in progress: building command string :cactus:
+    }
+}, 1)

--- a/example/simple.js
+++ b/example/simple.js
@@ -34,4 +34,8 @@ git.log(function (array) {
   //     'first commit',
   //     '2 days ago',
   //     'Thomas Blobaum' ] ]
-})
+}, 5)
+
+git.logobj(function(array) {
+  console.log('logobj', array);
+}, 5)

--- a/index.js
+++ b/index.js
@@ -1,13 +1,36 @@
 var exec = require('child_process').exec
 
-function _command (cmd, cb) {
-  exec(cmd, { cwd: __dirname, maxBuffer: 1024 * 1024 }, function (err, stdout, stderr) {
-    if (err !== null) {
-		console.log('[NODE-GIT-REV] exec error: ' + err);
-		cb(null);
-	}
-    cb(stdout.slice(0, -1));
-  })
+// a forbidden set of characters, use something that will never occur in a commit message.
+var logsplit_string = '  |  ';
+
+// special tags that can be used in logobj_properties instead of format strings.
+var SPECIAL = {
+  TIME:0, // To get a time object since the commit, rather than a git string "minutes ago"
+};
+
+// the format of the object that will be built when logobj is called paired to the git log format string used to get it.
+// alternatively we can use special parameters from SPECIAL to indicate we need a fancy version of what would otherwise be text.
+var logobj_properties = {
+  sha:{long:'%H', short:'%h'},
+  time:{ago:'%cr', time:SPECIAL.TIME},
+  author:'%an',
+  msg:'%s'
+};
+
+var logobj_property_info = [];
+
+// the string to use for logobj before any limit is added.
+var logobj_command_string = 'git log --no-color --pretty=format:\"%H'+logsplit_string+'%cr'+logsplit_string+'%an'+logsplit_string+'%s\" --abbrev-commit';
+
+var _populate_logobj = function(line) {
+  var logobj = {};
+  var splt = line.split(logsplit_string);
+  for(var property in logobj_properties) {
+    if(logobj_properties.hasOwnProperty(property)) {
+
+    }
+  }
+  return logobj;
 }
 
 module.exports = {
@@ -23,25 +46,87 @@ module.exports = {
   , tag : function (cb) {
       _command('git describe --always --tag --abbrev=0', cb)
     }
-  , log : function (cb, limit) {
+  , logobj : function(cb, limit) {
       var cmd_string = 'git log --no-color --pretty=format:\"%H  |  %cr  |  %an  |  %s\" --abbrev-commit';
       if(limit != null && !isNaN(limit)) {
          cmd_string += ' -'+limit;
       }
       _command(cmd_string, function (str) {
-         var logs = [];
-	 if ( str !== null ) {
-      	    (str.split('\n')).forEach(function(line, line_idx) {
-      	       var parsed_line = line.split('  |  ');
-      	       logs.push([
-      	           parsed_line[0],
-      	           parsed_line[3],
-      	           parsed_line[1],
-      	           parsed_line[2]
-      	       ]);
-      	    });
-      	 };
-	 cb(logs);
+      var logs = [];
+      if ( str !== null ) {
+        (str.split('\n')).forEach(function(line, line_idx) {
+          var parsed_line = line.split('  |  ');
+            logs.push({
+              sha:{long:parsed_line[0], short:''},
+              msg:parsed_line[3],
+              time:{ago:parsed_line[1]},
+              author:parsed_line[2]
+            });
+          });
+        };
+        cb(logs);
+      });
+  }
+  , log : function (cb, limit) {
+      var cmd_string = 'git log --no-color --pretty=format:\"%H'+logsplit_string+'%cr'+logsplit_string+'%an'+logsplit_string+'%s\" --abbrev-commit';
+      if(limit != null && !isNaN(limit)) {
+         cmd_string += ' -'+limit;
+      }
+      _command(cmd_string, function (str) {
+      var logs = [];
+      if ( str !== null ) {
+        (str.split('\n')).forEach(function(line, line_idx) {
+          var parsed_line = line.split(logsplit_string);
+            logs.push([
+              parsed_line[0],
+              parsed_line[3],
+              parsed_line[1],
+              parsed_line[2]
+            ]);
+          });
+        };
+        cb(logs);
       });
    }
 }
+
+
+function _command (cmd, cb) {
+  exec(cmd, { cwd: __dirname, maxBuffer: 1024 * 1024 }, function (err, stdout, stderr) {
+    if (err !== null) {
+    console.log('[NODE-GIT-REV] exec error: ' + err);
+    cb(null);
+  }
+    cb(stdout.slice(0, -1));
+  })
+}
+
+var _setup_property_info = function(){
+  var i = 0;
+  var _recursively_add_property = function(obj, rootname) {
+    for(var property in obj) {
+      if(obj.hasOwnProperty(property)) {
+        var value = obj[property];
+
+        if(typeof value === "string" || !isNaN(value)) {
+          logobj_property_info.push({index:i, name:(rootname!=''?rootname+'.':'')+property, command: value});
+          i++;
+        } else {
+
+          _recursively_add_property(value, (rootname!=''?rootname+'.':'')+property);
+        }
+      }
+    }
+  };
+  _recursively_add_property(logobj_properties, '');
+  //console.log('info', logobj_property_info);
+}();
+
+var _setup_command_string = function() {
+  //logobj_command_string = '';
+  var cmdstr = '';
+  for(var i = 0; i < logobj_property_info.length; ++i) {
+    logobj_property_info
+  }
+  console.log('cmdstr', cmdstr);
+}();

--- a/index.js
+++ b/index.js
@@ -126,7 +126,9 @@ var _setup_command_string = function() {
   //logobj_command_string = '';
   var cmdstr = '';
   for(var i = 0; i < logobj_property_info.length; ++i) {
-    logobj_property_info
+    if(isNaN(logobj_property_info.command)) {
+      cmdstr += logobj_property_info.command;
+    }
   }
   console.log('cmdstr', cmdstr);
 }();

--- a/index.js
+++ b/index.js
@@ -1,37 +1,30 @@
 var exec = require('child_process').exec
 
-// a forbidden set of characters, use something that will never occur in a commit message.
-var logsplit_string = '  |  ';
-
 // special tags that can be used in logobj_properties instead of format strings.
 var SPECIAL = {
-  TIME:0, // To get a time object since the commit, rather than a git string "minutes ago"
+  AUTHOR_DATEOBJ: 0, // A Date() object for the author time.
+  COMMITTER_DATEOBJ: 1, // A Date() object for the committer time.
 };
 
-// the format of the object that will be built when logobj is called paired to the git log format string used to get it.
-// alternatively we can use special parameters from SPECIAL to indicate we need a fancy version of what would otherwise be text.
+// This is the structure of the log info returned in an array from logobj. You can change the variable names as you see fit and
+// add or remove format strings as defined here:(http://git-scm.com/docs/pretty-formats). There are also special cases as defined
+// in SPECIAL.
 var logobj_properties = {
-  sha:{long:'%H', short:'%h'},
-  time:{ago:'%cr', time:SPECIAL.TIME},
-  author:'%an',
-  msg:'%s'
+  commit: { long_hash: '%H', short_hash: '%h' },
+  tree: { long_hash: '%T', short_hash: '%t' },
+  author: { name:'%aN', email:'%aE', date: { unix:'%at', relative:'%ar',  ISO:'%ai', date_obj:SPECIAL.AUTHOR_DATEOBJ } },
+  committer: { name:'%cN', email:'%cE', date: { unix:'%ct', relative:'%cr',  ISO:'%ci', date_obj:SPECIAL.COMMITTER_DATEOBJ } },
+  message: { encoding:'%e', subject:'%s', body:'%b', signature: { good:'%G?', signer:'%GS', key:'%GK' } }
 };
 
-var logobj_property_info = [];
+var special_case_commands = [];
+special_case_commands[SPECIAL.AUTHOR_DATEOBJ] = '%at';
+special_case_commands[SPECIAL.COMMITTER_DATEOBJ] = '%ct';
 
-// the string to use for logobj before any limit is added.
-var logobj_command_string = 'git log --no-color --pretty=format:\"%H'+logsplit_string+'%cr'+logsplit_string+'%an'+logsplit_string+'%s\" --abbrev-commit';
-
-var _populate_logobj = function(line) {
-  var logobj = {};
-  var splt = line.split(logsplit_string);
-  for(var property in logobj_properties) {
-    if(logobj_properties.hasOwnProperty(property)) {
-
-    }
-  }
-  return logobj;
-}
+var special_case_operations = [];
+var _unix_to_date = function(value) { return new Date(Date(value * 1000)); };
+special_case_operations[SPECIAL.AUTHOR_DATEOBJ] = _unix_to_date;
+special_case_operations[SPECIAL.COMMITTER_DATEOBJ] = _unix_to_date;
 
 module.exports = {
     short : function (cb) {
@@ -47,28 +40,7 @@ module.exports = {
       _command('git describe --always --tag --abbrev=0', cb)
     }
   , logobj : function(cb, limit) {
-      var cmd_string = 'git log --no-color --pretty=format:\"%H  |  %cr  |  %an  |  %s\" --abbrev-commit';
-      if(limit != null && !isNaN(limit)) {
-         cmd_string += ' -'+limit;
-      }
-      _command(cmd_string, function (str) {
-      var logs = [];
-      if ( str !== null ) {
-        (str.split('\n')).forEach(function(line, line_idx) {
-          var parsed_line = line.split('  |  ');
-            logs.push({
-              sha:{long:parsed_line[0], short:''},
-              msg:parsed_line[3],
-              time:{ago:parsed_line[1]},
-              author:parsed_line[2]
-            });
-          });
-        };
-        cb(logs);
-      });
-  }
-  , log : function (cb, limit) {
-      var cmd_string = 'git log --no-color --pretty=format:\"%H'+logsplit_string+'%cr'+logsplit_string+'%an'+logsplit_string+'%s\" --abbrev-commit';
+      var cmd_string = logobj_command_string;
       if(limit != null && !isNaN(limit)) {
          cmd_string += ' -'+limit;
       }
@@ -77,12 +49,60 @@ module.exports = {
       if ( str !== null ) {
         (str.split('\n')).forEach(function(line, line_idx) {
           var parsed_line = line.split(logsplit_string);
-            logs.push([
-              parsed_line[0],
-              parsed_line[3],
-              parsed_line[1],
-              parsed_line[2]
-            ]);
+          var parsed_obj = {};
+          for(var i = 0; i < logobj_property_info.length; ++i) {
+            // for use later once the value is parsed out
+            var value = parsed_line[logobj_property_info[i].index];
+            var cmd = logobj_property_info[i].command;
+            // split the variable name on dots so we can add intermediate objects before assigning the parsed value
+            var dots_split = logobj_property_info[i].name.split('.');
+            var latest_obj = parsed_obj;
+
+            // after looping latest_obj should be pointing to the unassigned variable we want to store our value
+            for(var j = 0; j < dots_split.length-1; ++j) {
+              // create it if it doesn't exist yet
+              if(latest_obj[dots_split[j]] == undefined) {
+                latest_obj[dots_split[j]] = {};
+              }
+              latest_obj = latest_obj[dots_split[j]];
+            }
+
+            // is a special case?
+            if(!isNaN(cmd)) {
+              value = special_case_operations[cmd](value);
+            }
+
+            latest_obj[dots_split[dots_split.length-1]] = value;
+          }
+
+          logs.push(parsed_obj);
+        });
+      };
+      cb(logs);
+    });
+  }
+  , log : function (cb, limit, format) {
+      if(format == null || isNaN(format.length)) {
+        format = ['%H', '%an', '%cr', '%s'];
+      }
+      var cmd_string = 'git log --no-color --pretty=format:\"';
+      for(var i = 0; i < format.length; ++i) {
+        cmd_string += format[i];
+        if(i != format.length -1) {
+          cmd_string += logsplit_string;
+        }
+      }
+      cmd_string += '\" --abbrev-commit';
+      console.log('cmd', cmd_string);
+      if(limit != null && !isNaN(limit)) {
+         cmd_string += ' -'+limit;
+      }
+      _command(cmd_string, function (str) {
+      var logs = [];
+      if ( str !== null ) {
+        (str.split('\n')).forEach(function(line, line_idx) {
+          var parsed_line = line.split(logsplit_string);
+            logs.push(parsed_line);
           });
         };
         cb(logs);
@@ -90,18 +110,27 @@ module.exports = {
    }
 }
 
+// a forbidden set of characters, use something that will never occur in a commit message.
+var logsplit_string = '  |  ';
+
+// array of information about the properties contained in logobj_properties
+// logobj_property_info = [{index:0, name:'foo.bar', command:'%H'}]
+var logobj_property_info = [];
+
+// the string to use for logobj before any limit is added.
+var logobj_command_string = '';
 
 function _command (cmd, cb) {
   exec(cmd, { cwd: __dirname, maxBuffer: 1024 * 1024 }, function (err, stdout, stderr) {
     if (err !== null) {
-    console.log('[NODE-GIT-REV] exec error: ' + err);
-    cb(null);
-  }
-    cb(stdout.slice(0, -1));
-  })
+      console.log('[NODE-GIT-REV] exec error: ' + err);
+      cb(null);
+    }
+    cb(stdout.slice(0));
+  });
 }
 
-var _setup_property_info = function(){
+{ // Setup logobj_property_info from logobj_properties
   var i = 0;
   var _recursively_add_property = function(obj, rootname) {
     for(var property in obj) {
@@ -112,23 +141,29 @@ var _setup_property_info = function(){
           logobj_property_info.push({index:i, name:(rootname!=''?rootname+'.':'')+property, command: value});
           i++;
         } else {
-
           _recursively_add_property(value, (rootname!=''?rootname+'.':'')+property);
         }
       }
     }
   };
   _recursively_add_property(logobj_properties, '');
-  //console.log('info', logobj_property_info);
-}();
+}
 
-var _setup_command_string = function() {
-  //logobj_command_string = '';
-  var cmdstr = '';
+
+{ // Setup command string
+  logobj_command_string = 'git log --no-color --pretty=format:\"';
   for(var i = 0; i < logobj_property_info.length; ++i) {
-    if(isNaN(logobj_property_info.command)) {
-      cmdstr += logobj_property_info.command;
+    // just a simple command string?
+    if(isNaN(logobj_property_info[i].command)) {
+      logobj_command_string += logobj_property_info[i].command;
+    } 
+    else { // special case
+      logobj_command_string += special_case_commands[logobj_property_info[i].command];
+    }
+
+    if(i != logobj_property_info.length-1) {
+      logobj_command_string += logsplit_string;
     }
   }
-  console.log('cmdstr', cmdstr);
-}();
+  logobj_command_string += '\" --abbrev-commit';
+}


### PR DESCRIPTION
#### features

I didn't like how the array of git info returned an array of pre-defined info per commit. I changed it so you can specify a format (default is `format = ['%H', '%an', '%cr', '%s'];`).

I also added the ability to return an object structured in a more user friendly way. In the git-rev index there's an object that looks like:

``` js
var logobj_properties = {
  commit: { long_hash: '%H', short_hash: '%h' },
  tree: { long_hash: '%T', short_hash: '%t' },
  author: { name:'%aN', email:'%aE', date: { unix:'%at', relative:'%ar',  ISO:'%ai', date_obj:SPECIAL.AUTHOR_DATEOBJ } },
  committer: { name:'%cN', email:'%cE', date: { unix:'%ct', relative:'%cr',  ISO:'%ci', date_obj:SPECIAL.COMMITTER_DATEOBJ } },
  message: { encoding:'%e', subject:'%s', body:'%b', signature: { good:'%G?', signer:'%GS', key:'%GK' } }
};
```

That pairs object and member names with a git format string to use. The two `SPECIAL.*` are special cases I found useful, these specifically return a new Date() object for the author/committer objects.

The result is the callback getting an array of objects where you can use those named members like so:

``` js
console.log(array[0].commit.long_hash);
console.log(array[0].author.email);
console.log(array[0].message.subject);
```

Besides my own usability, I figured I could encourage hacking this module if I did things this way. Makes it easy to dig in and make the output look however you want by just changing one js object.
#### bug fix

The slice in `_command` had a -1 param, which would not take in the last character of a buffer. I removed that param with the assumption it wasn't needed (please correct me if Im wrong).
